### PR TITLE
Рефакторинг сборок с целью получения независимых билдов

### DIFF
--- a/.teamcity/AndroidBundleTool.kt
+++ b/.teamcity/AndroidBundleTool.kt
@@ -1,9 +1,7 @@
 import common.DockerImageBuildType
 
 object AndroidBundleTool : DockerImageBuildType(
-    Params(
-        name = "Android BundleTool",
-        imageName = "android-bundletool",
-        executionTimeoutMin = 5,
-    )
+    name = "Android BundleTool",
+    imageName = "android-bundletool",
+    executionTimeoutMin = 5,
 )

--- a/.teamcity/AndroidBundleTool.kt
+++ b/.teamcity/AndroidBundleTool.kt
@@ -1,38 +1,9 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object AndroidBundleTool : BuildType({
-
-    name = "Android BundleTool"
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 5
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-    steps {
-
-        addBuildDockerImageSteps("android-bundletool")
-
-    }
-
-})
+object AndroidBundleTool : DockerImageBuildType(
+    Params(
+        name = "Android BundleTool",
+        imageName = "android-bundletool",
+        executionTimeoutMin = 5,
+    )
+)

--- a/.teamcity/AndroidBundleTool.kt
+++ b/.teamcity/AndroidBundleTool.kt
@@ -2,6 +2,6 @@ import common.DockerImageBuildType
 
 object AndroidBundleTool : DockerImageBuildType(
     name = "Android BundleTool",
-    imageName = "android-bundletool",
+    dirName = "android-bundletool",
     executionTimeoutMin = 5,
 )

--- a/.teamcity/AndroidSdk.kt
+++ b/.teamcity/AndroidSdk.kt
@@ -1,50 +1,10 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object AndroidSdk : BuildType({
-
-    name = "Android SDK"
-
-    dependencies {
-        snapshot(JavaJdk) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-    }
-
-    params {
-        param("env.BUILD_BRANCH", "")
-    }
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    steps {
-
-        addBuildDockerImageSteps(
-            "android-sdk",
-            "java-jdk"
-        )
-
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 20
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-})
+object AndroidSdk : DockerImageBuildType(
+    Params(
+        name = "Android SDK",
+        imageName = "android-sdk",
+        parent = Params.ParentBuildType(JavaJdk, "java-jdk"),
+        executionTimeoutMin = 20,
+    )
+)

--- a/.teamcity/AndroidSdk.kt
+++ b/.teamcity/AndroidSdk.kt
@@ -1,10 +1,8 @@
 import common.DockerImageBuildType
 
 object AndroidSdk : DockerImageBuildType(
-    Params(
-        name = "Android SDK",
-        imageName = "android-sdk",
-        parent = JavaJdk,
-        executionTimeoutMin = 20,
-    )
+    name = "Android SDK",
+    imageName = "android-sdk",
+    parent = JavaJdk,
+    executionTimeoutMin = 20,
 )

--- a/.teamcity/AndroidSdk.kt
+++ b/.teamcity/AndroidSdk.kt
@@ -2,7 +2,7 @@ import common.DockerImageBuildType
 
 object AndroidSdk : DockerImageBuildType(
     name = "Android SDK",
-    imageName = "android-sdk",
+    dirName = "android-sdk",
     parent = JavaJdk,
     executionTimeoutMin = 20,
 )

--- a/.teamcity/AndroidSdk.kt
+++ b/.teamcity/AndroidSdk.kt
@@ -4,7 +4,7 @@ object AndroidSdk : DockerImageBuildType(
     Params(
         name = "Android SDK",
         imageName = "android-sdk",
-        parent = Params.ParentBuildType(JavaJdk, "java-jdk"),
+        parent = JavaJdk,
         executionTimeoutMin = 20,
     )
 )

--- a/.teamcity/AndroidSdk.kt
+++ b/.teamcity/AndroidSdk.kt
@@ -24,8 +24,8 @@ object AndroidSdk : BuildType({
     steps {
 
         addBuildDockerImageSteps(
-                "android-sdk",
-                "java-jdk"
+            "android-sdk",
+            "java-jdk"
         )
 
     }

--- a/.teamcity/Base.kt
+++ b/.teamcity/Base.kt
@@ -2,6 +2,6 @@ import common.DockerImageBuildType
 
 object Base : DockerImageBuildType(
     name = "Base",
-    imageName = "base",
+    dirName = "base",
     executionTimeoutMin = 5,
 )

--- a/.teamcity/Base.kt
+++ b/.teamcity/Base.kt
@@ -1,42 +1,9 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object Base : BuildType({
-
-    name = "Base"
-
-    params {
-        param("env.BUILD_BRANCH", "")
-    }
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 5
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-    steps {
-
-        addBuildDockerImageSteps("base")
-
-    }
-
-})
+object Base : DockerImageBuildType(
+    Params(
+        name = "Base",
+        imageName = "base",
+        executionTimeoutMin = 5,
+    )
+)

--- a/.teamcity/Base.kt
+++ b/.teamcity/Base.kt
@@ -1,9 +1,7 @@
 import common.DockerImageBuildType
 
 object Base : DockerImageBuildType(
-    Params(
-        name = "Base",
-        imageName = "base",
-        executionTimeoutMin = 5,
-    )
+    name = "Base",
+    imageName = "base",
+    executionTimeoutMin = 5,
 )

--- a/.teamcity/FirebaseTools.kt
+++ b/.teamcity/FirebaseTools.kt
@@ -1,38 +1,9 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object FirebaseTools : BuildType({
-
-    name = "Firebase Tools"
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 5
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-    steps {
-
-        addBuildDockerImageSteps("firebase-tools")
-
-    }
-
-})
+object FirebaseTools : DockerImageBuildType(
+    Params(
+        name = "Firebase Tools",
+        imageName = "firebase-tools",
+        executionTimeoutMin = 5,
+    )
+)

--- a/.teamcity/FirebaseTools.kt
+++ b/.teamcity/FirebaseTools.kt
@@ -1,9 +1,7 @@
 import common.DockerImageBuildType
 
 object FirebaseTools : DockerImageBuildType(
-    Params(
-        name = "Firebase Tools",
-        imageName = "firebase-tools",
-        executionTimeoutMin = 5,
-    )
+    name = "Firebase Tools",
+    imageName = "firebase-tools",
+    executionTimeoutMin = 5,
 )

--- a/.teamcity/FirebaseTools.kt
+++ b/.teamcity/FirebaseTools.kt
@@ -2,6 +2,6 @@ import common.DockerImageBuildType
 
 object FirebaseTools : DockerImageBuildType(
     name = "Firebase Tools",
-    imageName = "firebase-tools",
+    dirName = "firebase-tools",
     executionTimeoutMin = 5,
 )

--- a/.teamcity/JavaJdk.kt
+++ b/.teamcity/JavaJdk.kt
@@ -2,7 +2,7 @@ import common.DockerImageBuildType
 
 object JavaJdk : DockerImageBuildType(
     name = "Java Development Kit",
-    imageName = "java-jdk",
+    dirName = "java-jdk",
     parent = Base,
     executionTimeoutMin = 5,
 )

--- a/.teamcity/JavaJdk.kt
+++ b/.teamcity/JavaJdk.kt
@@ -1,10 +1,8 @@
 import common.DockerImageBuildType
 
 object JavaJdk : DockerImageBuildType(
-    Params(
-        name = "Java Development Kit",
-        imageName = "java-jdk",
-        parent = Base,
-        executionTimeoutMin = 5,
-    )
+    name = "Java Development Kit",
+    imageName = "java-jdk",
+    parent = Base,
+    executionTimeoutMin = 5,
 )

--- a/.teamcity/JavaJdk.kt
+++ b/.teamcity/JavaJdk.kt
@@ -4,7 +4,7 @@ object JavaJdk : DockerImageBuildType(
     Params(
         name = "Java Development Kit",
         imageName = "java-jdk",
-        parent = Params.ParentBuildType(Base, "base"),
+        parent = Base,
         executionTimeoutMin = 5,
     )
 )

--- a/.teamcity/JavaJdk.kt
+++ b/.teamcity/JavaJdk.kt
@@ -43,8 +43,8 @@ object JavaJdk : BuildType({
     steps {
 
         addBuildDockerImageSteps(
-                "java-jdk",
-                "base"
+            "java-jdk",
+            "base"
         )
 
     }

--- a/.teamcity/JavaJdk.kt
+++ b/.teamcity/JavaJdk.kt
@@ -1,52 +1,10 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object JavaJdk : BuildType({
-
-    name = "Java Development Kit"
-
-    dependencies {
-        snapshot(Base) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-    }
-
-    params {
-        param("env.BUILD_BRANCH", "")
-    }
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 5
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-    steps {
-
-        addBuildDockerImageSteps(
-            "java-jdk",
-            "base"
-        )
-
-    }
-
-})
+object JavaJdk : DockerImageBuildType(
+    Params(
+        name = "Java Development Kit",
+        imageName = "java-jdk",
+        parent = Params.ParentBuildType(Base, "base"),
+        executionTimeoutMin = 5,
+    )
+)

--- a/.teamcity/Lokalise.kt
+++ b/.teamcity/Lokalise.kt
@@ -22,8 +22,8 @@ object Lokalise : BuildType({
     steps {
 
         addBuildDockerImageSteps(
-                "lokalise",
-                "base"
+            "lokalise",
+            "base"
         )
 
     }

--- a/.teamcity/Lokalise.kt
+++ b/.teamcity/Lokalise.kt
@@ -1,10 +1,8 @@
 import common.DockerImageBuildType
 
 object Lokalise : DockerImageBuildType(
-    Params(
-        name = "Lokalise",
-        imageName = "lokalise",
-        parent = Base,
-        executionTimeoutMin = 20,
-    )
+    name = "Lokalise",
+    imageName = "lokalise",
+    parent = Base,
+    executionTimeoutMin = 20,
 )

--- a/.teamcity/Lokalise.kt
+++ b/.teamcity/Lokalise.kt
@@ -1,48 +1,10 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object Lokalise : BuildType({
-
-    name = "Lokalise"
-
-    dependencies {
-        snapshot(Base) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-    }
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    steps {
-
-        addBuildDockerImageSteps(
-            "lokalise",
-            "base"
-        )
-
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 20
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-})
+object Lokalise : DockerImageBuildType(
+    Params(
+        name = "Lokalise",
+        imageName = "lokalise",
+        parent = Params.ParentBuildType(Base, "base"),
+        executionTimeoutMin = 20,
+    )
+)

--- a/.teamcity/Lokalise.kt
+++ b/.teamcity/Lokalise.kt
@@ -2,7 +2,7 @@ import common.DockerImageBuildType
 
 object Lokalise : DockerImageBuildType(
     name = "Lokalise",
-    imageName = "lokalise",
+    dirName = "lokalise",
     parent = Base,
     executionTimeoutMin = 20,
 )

--- a/.teamcity/Lokalise.kt
+++ b/.teamcity/Lokalise.kt
@@ -4,7 +4,7 @@ object Lokalise : DockerImageBuildType(
     Params(
         name = "Lokalise",
         imageName = "lokalise",
-        parent = Params.ParentBuildType(Base, "base"),
+        parent = Base,
         executionTimeoutMin = 20,
     )
 )

--- a/.teamcity/ProjectMyBookAndroid.kt
+++ b/.teamcity/ProjectMyBookAndroid.kt
@@ -3,7 +3,7 @@ import common.DockerImageBuildType
 object ProjectMyBookAndroid : DockerImageBuildType(
     name = "Project MyBook Android",
     description = "Image for MyBook Android project",
-    imageName = "project-mybook-android-build",
+    dirName = "project-mybook-android-build",
     parent = AndroidSdk,
     executionTimeoutMin = 10,
 )

--- a/.teamcity/ProjectMyBookAndroid.kt
+++ b/.teamcity/ProjectMyBookAndroid.kt
@@ -5,7 +5,7 @@ object ProjectMyBookAndroid : DockerImageBuildType(
         name = "Project MyBook Android",
         description = "Image for MyBook Android project",
         imageName = "project-mybook-android-build",
-        parent = Params.ParentBuildType(AndroidSdk, "android-sdk"),
+        parent = AndroidSdk,
         executionTimeoutMin = 10,
     )
 )

--- a/.teamcity/ProjectMyBookAndroid.kt
+++ b/.teamcity/ProjectMyBookAndroid.kt
@@ -1,51 +1,11 @@
-import common.addBuildDockerImageSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import common.DockerImageBuildType
 
-object ProjectMyBookAndroid : BuildType({
-
-    name = "Project MyBook Android"
-    description = "Image for MyBook Android project"
-
-    dependencies {
-        snapshot(AndroidSdk) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-    }
-
-    params {
-        param("env.BUILD_BRANCH", "")
-    }
-
-    vcs {
-        root(DslContext.settingsRoot)
-    }
-
-    steps {
-
-        addBuildDockerImageSteps(
-            "project-mybook-android-build",
-            "android-sdk"
-        )
-
-    }
-
-    triggers {
-        vcs {
-            branchFilter = ""
-        }
-    }
-
-    failureConditions {
-        executionTimeoutMin = 10
-    }
-
-    features {
-        swabra {
-            forceCleanCheckout = true
-            verbose = true
-        }
-    }
-
-})
+object ProjectMyBookAndroid : DockerImageBuildType(
+    Params(
+        name = "Project MyBook Android",
+        description = "Image for MyBook Android project",
+        imageName = "project-mybook-android-build",
+        parent = Params.ParentBuildType(AndroidSdk, "android-sdk"),
+        executionTimeoutMin = 10,
+    )
+)

--- a/.teamcity/ProjectMyBookAndroid.kt
+++ b/.teamcity/ProjectMyBookAndroid.kt
@@ -1,11 +1,9 @@
 import common.DockerImageBuildType
 
 object ProjectMyBookAndroid : DockerImageBuildType(
-    Params(
-        name = "Project MyBook Android",
-        description = "Image for MyBook Android project",
-        imageName = "project-mybook-android-build",
-        parent = AndroidSdk,
-        executionTimeoutMin = 10,
-    )
+    name = "Project MyBook Android",
+    description = "Image for MyBook Android project",
+    imageName = "project-mybook-android-build",
+    parent = AndroidSdk,
+    executionTimeoutMin = 10,
 )

--- a/.teamcity/common/DockerImageBuildType.kt
+++ b/.teamcity/common/DockerImageBuildType.kt
@@ -16,7 +16,7 @@ open class DockerImageBuildType(params: Params) : BuildType({
 
     params.parent?.let { dependsOn ->
         dependencies {
-            snapshot(dependsOn.buildType) {
+            snapshot(dependsOn) {
                 onDependencyFailure = FailureAction.FAIL_TO_START
             }
         }
@@ -33,8 +33,8 @@ open class DockerImageBuildType(params: Params) : BuildType({
     steps {
 
         addBuildDockerImageSteps(
-            params.imageName,
-            params.parent?.imageName,
+            imageName = params.imageName,
+            parentImageName = params.parent?.imageName,
         )
 
     }
@@ -58,19 +58,14 @@ open class DockerImageBuildType(params: Params) : BuildType({
 
 }) {
 
+    private val imageName: String = params.imageName
+
     data class Params(
         val name: String,
         val description: String? = null,
         val imageName: String,
-        val parent: ParentBuildType? = null,
+        val parent: DockerImageBuildType? = null,
         val executionTimeoutMin: Int,
-    ) {
-
-        data class ParentBuildType(
-            val buildType: BuildType,
-            val imageName: String,
-        )
-
-    }
+    )
 
 }

--- a/.teamcity/common/DockerImageBuildType.kt
+++ b/.teamcity/common/DockerImageBuildType.kt
@@ -9,7 +9,10 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 open class DockerImageBuildType(params: Params) : BuildType({
 
     name = params.name
-    description = params.description
+
+    params.description?.let {
+        description = it
+    }
 
     params.parent?.let { dependsOn ->
         dependencies {
@@ -57,9 +60,9 @@ open class DockerImageBuildType(params: Params) : BuildType({
 
     data class Params(
         val name: String,
-        val description: String,
+        val description: String? = null,
         val imageName: String,
-        val parent: ParentBuildType?,
+        val parent: ParentBuildType? = null,
         val executionTimeoutMin: Int,
     ) {
 

--- a/.teamcity/common/DockerImageBuildType.kt
+++ b/.teamcity/common/DockerImageBuildType.kt
@@ -11,8 +11,10 @@ open class DockerImageBuildType(
     description: String? = null,
     parent: DockerImageBuildType? = null,
     executionTimeoutMin: Int,
-    private val imageName: String,
+    dirName: String,
 ) : BuildType({
+
+    val dockerImageName: String = dirName
 
     this.name = name
 
@@ -33,14 +35,17 @@ open class DockerImageBuildType(
     }
 
     vcs {
-        root(DslContext.settingsRoot)
+        root(
+            DslContext.settingsRoot,
+            "+:$dirName",
+        )
     }
 
     steps {
 
         addBuildDockerImageSteps(
-            imageName = imageName,
-            parentImageName = parent?.imageName,
+            imageName = dockerImageName,
+            parentImageName = parent?.dockerImageName,
         )
 
     }
@@ -62,4 +67,8 @@ open class DockerImageBuildType(
         }
     }
 
-})
+}) {
+
+    private val dockerImageName: String = dirName
+
+}

--- a/.teamcity/common/DockerImageBuildType.kt
+++ b/.teamcity/common/DockerImageBuildType.kt
@@ -1,0 +1,73 @@
+package common
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+
+open class DockerImageBuildType(params: Params) : BuildType({
+
+    name = params.name
+    description = params.description
+
+    params.parent?.let { dependsOn ->
+        dependencies {
+            snapshot(dependsOn.buildType) {
+                onDependencyFailure = FailureAction.FAIL_TO_START
+            }
+        }
+    }
+
+    params {
+        param("env.BUILD_BRANCH", "")
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+    }
+
+    steps {
+
+        addBuildDockerImageSteps(
+            params.imageName,
+            params.parent?.imageName,
+        )
+
+    }
+
+    triggers {
+        vcs {
+            branchFilter = ""
+        }
+    }
+
+    failureConditions {
+        executionTimeoutMin = params.executionTimeoutMin
+    }
+
+    features {
+        swabra {
+            forceCleanCheckout = true
+            verbose = true
+        }
+    }
+
+}) {
+
+    data class Params(
+        val name: String,
+        val description: String,
+        val imageName: String,
+        val parent: ParentBuildType?,
+        val executionTimeoutMin: Int,
+    ) {
+
+        data class ParentBuildType(
+            val buildType: BuildType,
+            val imageName: String,
+        )
+
+    }
+
+}

--- a/.teamcity/common/DockerImageBuildType.kt
+++ b/.teamcity/common/DockerImageBuildType.kt
@@ -6,15 +6,21 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
-open class DockerImageBuildType(params: Params) : BuildType({
+open class DockerImageBuildType(
+    name: String,
+    description: String? = null,
+    parent: DockerImageBuildType? = null,
+    executionTimeoutMin: Int,
+    private val imageName: String,
+) : BuildType({
 
-    name = params.name
+    this.name = name
 
-    params.description?.let {
-        description = it
+    description?.let {
+        this.description = it
     }
 
-    params.parent?.let { dependsOn ->
+    parent?.let { dependsOn ->
         dependencies {
             snapshot(dependsOn) {
                 onDependencyFailure = FailureAction.FAIL_TO_START
@@ -33,8 +39,8 @@ open class DockerImageBuildType(params: Params) : BuildType({
     steps {
 
         addBuildDockerImageSteps(
-            imageName = params.imageName,
-            parentImageName = params.parent?.imageName,
+            imageName = imageName,
+            parentImageName = parent?.imageName,
         )
 
     }
@@ -46,7 +52,7 @@ open class DockerImageBuildType(params: Params) : BuildType({
     }
 
     failureConditions {
-        executionTimeoutMin = params.executionTimeoutMin
+        this.executionTimeoutMin = executionTimeoutMin
     }
 
     features {
@@ -56,16 +62,4 @@ open class DockerImageBuildType(params: Params) : BuildType({
         }
     }
 
-}) {
-
-    private val imageName: String = params.imageName
-
-    data class Params(
-        val name: String,
-        val description: String? = null,
-        val imageName: String,
-        val parent: DockerImageBuildType? = null,
-        val executionTimeoutMin: Int,
-    )
-
-}
+})

--- a/.teamcity/common/addBuildDockerImageSteps.kt
+++ b/.teamcity/common/addBuildDockerImageSteps.kt
@@ -5,8 +5,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 fun BuildSteps.addBuildDockerImageSteps(
-        imageName: String,
-        parentImageName: String? = null
+    imageName: String,
+    parentImageName: String? = null
 ) {
 
     val repositoryHost = "%docker.registry.host%"
@@ -30,9 +30,9 @@ fun BuildSteps.addBuildDockerImageSteps(
     }
 
     val buildArgsString = buildArgs.entries
-            .joinToString(
-                    separator = " "
-            ) { "--build-arg ${it.key}=${it.value}" }
+        .joinToString(
+            separator = " "
+        ) { "--build-arg ${it.key}=${it.value}" }
 
     script {
         name = "Pull existing image from Registry"

--- a/android-bundletool/Dockerfile
+++ b/android-bundletool/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk/openjdk8:jdk8u252-b09-alpine-slim
 
-RUN VERSION=0.15.0; \
+RUN VERSION=1.0.0; \
     FILE_NAME=bundletool-all-${VERSION}.jar; \
     DIR=/opt/android/bundletool; \
     FILE_PATH=$DIR/lib/$FILE_NAME; \


### PR DESCRIPTION
Основная часть изменений это вынос общего родителя `DockerImageBuildType`. В нем собраны все общие части конфигураций, а различия задаются через параметры конструктора.

Чтобы сборки были независимые и собирались только измененные, добавлено правило чекаута в разделе vcs. Пока оно не работает и я сильно надеюсь, что это из-за того, что изменения не слиты в дефолтную ветку.